### PR TITLE
V0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,71 +29,14 @@ With Courier installed, it is time to install the randomizer mod. To install the
 
 And the mod is now properly installed and ready to be loaded when you open up the game.
 
-#### Setup Save File for Randomizer
-
-The early versions of the randomizer mod are not setup to do really nice and fun things for you like properly prepare the game to be in the state we intend to start a randomizer seed in. Currently you start:
-
-* In the Tower of Time HQ (right after Linear)
-* You only have climbing claws
-* Some of the initial Tower of Time HQ and map collection cutscenes have already been watched
-* All of the portals are open
-
-Until we get that working, you will need to set your game to be in this state to work well with the randomizer. If you are lazy like I am then I have a not-very-fun-but-still-more-fun-then-doing-it-yourself solution for you. Along with the zip file you grabbed for the randomizer mod there should also be a text file. This file is a properly configured game save file that contains three randomizer file slots ready to go for you. All you need to do is:
-
-1. Download the 'RandomizerSaveGame.txt' file from the [Release](https://github.com/minous27/TheMessengerRandomizerMod/releases) you installed.
-2. Place the file in save file location for the game
-    * By default that is located at _'C:\Users\youruserhere\AppData\LocalLow\Sabotage Studio\The Messenger'_.
-3. Delete the original 'SaveGame.txt' file and rename the randomizer save file to 'SaveGame.txt'.
-
-You are all done! At this point you have the mod installed and the game in an apporiate state to begin running randomizer seeds. 
-
 ---
-### Using the Randomizer
+Randomizer Wiki
 ---
 
-Now that you are all installed and ready to play, lets take a look some of the functionality the mod provides.
+Please refer to [The Messenger Randomizer Wiki](https://github.com/minous27/TheMessengerRandomizerMod/wiki) for information on using the mod.
 
-#### Generate a New Randomizer Seed
+---
+### Contact Us
+---
 
-When you are ready to kick off a brand new seed: 
-
-1. Start up the game in whatever way you normally do. 
-2. Once you are on the Main Menu, select 'Options' -> 'Third Party Mod Options' -> 'Generate Random Seed'.
-3. You will be presented with a screen asking for a save slot number.
-    * Provide a number between 1-3 that corresponds to which randomizer save file you want to create a seed for.
-4. Press your confirm button to continue
-    * By default this is the 'Start' button on a controller or the 'Enter' key on keyboard.
-5. If you are returned to the Third Party Content screen, then the seed generation completed successfully and you may now start the file of your choice and begin playing.
-
-##### NOTE ABOUT EARLY RANDOMIZER SEEDS
-
-Keep in mind that there is currently **NO LOGIC** in my seed generation code. This means that it is possible, and very likely, that a seed you generate will not be beatable and will cause a softlock at some point. If you are not really interested in messing around with likely unbeatable seeds then you can provide a pre-generated seed for your game to use. I...haven't added this into the game for you to do easily yet because I suck *BUT* I can show you how to do it behind the scenes.
-
-#### Provide a Pre-Generated Seed
-
-Courier provides the ability for mods like this one to store information in a save file to keep track of between play sessions so that you don't *HAVE* to finish it in single sitting. For the moment, we can use this functionality to provide pre-generated seed numbers to for the game to use so we can be certain what seed we will be working with. To do this:
-
-1. Navigate to the same directory on your machine where the game's save files are located
-    * As a refresher, the default location is _'C:\Users\youruserhere\AppData\LocalLow\Sabotage Studio\The Messenger'_.
-2. Open the file 'ModSave.json' in whatever text editor you wish.
-3. Provide the seed number in the 'minous27RandoSeeds' Mod Option
-    * Depending on how familiar you are with JSON it may not be obvious how to do this and if this is your very first setup there may actually be nothing inside the 'Options' block. The value you will need to set is a pipe "|" deliminted string of numbers that represent seeds and the order they are in represent which file they are for.
-    * If you have nothing in your 'Options', an easy way to initially fill it is to follow the above directions to generate a new seed and then back all the way out to the main menu to allow the game to save that data into the file for you. You can also type the string in yourself if you're feeling frisky.
-    * Example mod option save string: 
-    ```json 
-    {"Options":[{"optionKey":"minous27RandoSeeds","optionValue":"|0|0|0"}]}
-    ```
-    * This example shows three '0's as seeds for all three file slots. You will replace that number with seed number you desire in the position that matches which file slot you intend to play on (so the first 0 represents the seed for the first save file).
-4. Save the file when you are done.
-
-Once these steps are complete if your game is already running you may have to restart it for these changes to take effect. You are now ready to select the applicable save file and begin playing some randomizer!
-
-Here are some example seed(s) that have been tested to be beatable (i mostly promise :3)
-
-* 39596
-
-#### Checking The Game Logs
-
-I have added quite a bit of logging into the mod to allow us to know things about the randomizer and the seed you are playing. For example, when you start the file and begin play or generate a new seed the spoiler log that shows what items are where gets printed to the games log. If you wish to view this log and see that information, you can find it in the game's install directory (the same place where the games .exe file is). The file is called 'log.txt'. 
-
-As a reminder, my example install destination is _'drive_name:\Steam\steamapps\common\The Messenger\'_.
+Any feedback on the randomizer would be greatly appreciated as it will only serve to improve the mod. If you wish to provide feedback/comments/issues or just want to stay up to date on the discussions, join [The Messenger Mods discord server!](https://discord.gg/xR5V8WH) 

--- a/RandomizedItemInserter.cs
+++ b/RandomizedItemInserter.cs
@@ -185,7 +185,7 @@ namespace MessengerRando
         bool PhantomEnemy_ReceiveHit(On.PhantomEnemy.orig_ReceiveHit orig, PhantomEnemy self, HitData hitData)
         {
             //We want phantom to not take damage if all notes have not been collected yet.
-            if(ItemRandomizerUtil.HasAllNotes())
+            if((!randoStateManager.IsRandomizedFile) || ItemRandomizerUtil.HasAllNotes())
             {
                 return orig(self, hitData);
             }

--- a/RandomizedItemInserter.cs
+++ b/RandomizedItemInserter.cs
@@ -2,6 +2,8 @@
 using Mod.Courier;
 using Mod.Courier.Module;
 using Mod.Courier.UI;
+using UnityEngine;
+using UnityEngine.EventSystems;
 using static Mod.Courier.UI.TextEntryButtonInfo;
 
 
@@ -14,6 +16,7 @@ namespace MessengerRando
         private RandomizerStateManager randoStateManager;       
 
         TextEntryButtonInfo generateSeedButton;
+        TextEntryButtonInfo enterSeedButton;
         SubMenuButtonInfo teleportToHqButton;
 
         public override void Load()
@@ -25,10 +28,16 @@ namespace MessengerRando
             //Initialize the randomizer state manager
             RandomizerStateManager.Initialize();
             randoStateManager = RandomizerStateManager.Instance;
+            RandomizerSaveMethod randomizerSaveMethod = new RandomizerSaveMethod(RANDO_OPTION_KEY);
+
 
             //Add generate mod option button
             generateSeedButton = Courier.UI.RegisterTextEntryModOptionButton(() => "Generate Random Seed", OnEnterRandoFileSlot, 1, () => "Which save slot would you like to start a rando seed?", () => "1", CharsetFlags.Number);
-            generateSeedButton.SaveMethod = new RandomizerSaveMethod(RANDO_OPTION_KEY);
+            generateSeedButton.SaveMethod = randomizerSaveMethod;
+
+            //Add Set seed mod option button
+            enterSeedButton = Courier.UI.RegisterTextEntryModOptionButton(() => "Set Randomizer Seed", OnEnterSeedNumber, 15, () => "What is the seed you would like to play?", null,  CharsetFlags.Number);
+            generateSeedButton.SaveMethod = randomizerSaveMethod;
 
             //Add teleport to HQ button\
             teleportToHqButton = Courier.UI.RegisterSubMenuModOptionButton(() => "Teleport to HQ", OnSelectTeleportToHq);
@@ -47,8 +56,10 @@ namespace MessengerRando
 
         public override void Initialize()
         {
-            //I only want the generate seed mod option available when not in the game.
+            //I only want the generate seed/enter seed mod options available when not in the game.
             generateSeedButton.IsEnabled = () => Manager<LevelManager>.Instance.GetCurrentLevelEnum() == ELevel.NONE;
+            enterSeedButton.IsEnabled = () => Manager<LevelManager>.Instance.GetCurrentLevelEnum() == ELevel.NONE;
+
             teleportToHqButton.IsEnabled = () => Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE;
         }
 
@@ -59,7 +70,7 @@ namespace MessengerRando
             int randoQuantity = quantity;
 
             //Lets make sure that the item they are collecting is supposed to be randomized
-            if (randoStateManager.CurrentLocationToItemMapping.ContainsKey(randoItemId))
+            if (randoStateManager.IsRandomizedFile && randoStateManager.CurrentLocationToItemMapping.ContainsKey(randoItemId))
             {
                 //Based on the item that is attempting to be added, determine what SHOULD be added instead
                 randoItemId = randoStateManager.CurrentLocationToItemMapping[itemId];
@@ -74,7 +85,7 @@ namespace MessengerRando
         {
             bool hasItem = false;
             //Check to make sure this is an item that was randomized and make sure we are not ignoring this specific trigger check
-            if (ItemRandomizerUtil.RandomizableLocations.Contains(self.item) && !ItemRandomizerUtil.TriggersToIgnoreRandoItemLogic.Contains(self.Owner.name))
+            if (randoStateManager.IsRandomizedFile && ItemRandomizerUtil.RandomizableLocations.Contains(self.item) && !ItemRandomizerUtil.TriggersToIgnoreRandoItemLogic.Contains(self.Owner.name))
             {
                 //Don't actually check for the item i have, check to see if I have the item that was at it's location.
                 int itemQuantity = Manager<InventoryManager>.Instance.GetItemQuantity(randoStateManager.CurrentLocationToItemMapping[self.item]);
@@ -109,7 +120,7 @@ namespace MessengerRando
         bool AwardNoteCutscene_ShouldPlay(On.AwardNoteCutscene.orig_ShouldPlay orig, AwardNoteCutscene self)
         {
             //Need to handle note cutscene triggers so they will play as long as I dont have the actual item it grants
-            if (randoStateManager.CurrentLocationToItemMapping.ContainsKey(self.noteToAward)) //Double checking to prevent errors
+            if (randoStateManager.IsRandomizedFile && randoStateManager.CurrentLocationToItemMapping.ContainsKey(self.noteToAward)) //Double checking to prevent errors
             {
                 bool shouldPlay = Manager<InventoryManager>.Instance.GetItemQuantity(randoStateManager.CurrentLocationToItemMapping[self.noteToAward]) <= 0 && !randoStateManager.IsNoteCutsceneTriggered(self.noteToAward);
                 randoStateManager.SetNoteCutsceneTriggered(self.noteToAward);
@@ -126,7 +137,7 @@ namespace MessengerRando
             
 
             //Check to make sure this is a cutscene i am configured to check, then check to make sure I actually have the item that is mapped to it
-            if(ItemRandomizerUtil.CutsceneMappings.ContainsKey(self.cutsceneId) && Manager<InventoryManager>.Instance.GetItemQuantity(ItemRandomizerUtil.CutsceneMappings[self.cutsceneId]) >= 1)
+            if(randoStateManager.IsRandomizedFile && ItemRandomizerUtil.CutsceneMappings.ContainsKey(self.cutsceneId) && Manager<InventoryManager>.Instance.GetItemQuantity(ItemRandomizerUtil.CutsceneMappings[self.cutsceneId]) >= 1)
             {
                 //Return true, this cutscene has "been played"
                 return true;
@@ -149,6 +160,7 @@ namespace MessengerRando
             {
                 Console.WriteLine($"Seed exists for file slot {fileSlot}. Generating mappings.");
                 randoStateManager.CurrentLocationToItemMapping = ItemRandomizerUtil.GenerateRandomizedMappings(randoStateManager.GetSeedForFileSlot(fileSlot));
+                randoStateManager.IsRandomizedFile = true;
             }
             else
             {
@@ -212,28 +224,61 @@ namespace MessengerRando
         }
         */
 
+        bool OnEnterSeedNumber(string seed)
+        {
+            if(seed == null || seed.Length < 1)
+            {
+                Console.WriteLine($"Invalid seed number '{seed}' provided");
+                return false;
+            }
+
+            TextEntryPopup fileSlotPopup = InitTextEntryPopup(enterSeedButton.addedTo, "Which save slot would you like to set this seed to?", (entry) => SetSeedForFileSlot(Convert.ToInt32(entry), Convert.ToInt32(seed)), 1, null, CharsetFlags.Number);
+            fileSlotPopup.onBack += () => {
+                fileSlotPopup.gameObject.SetActive(false);
+                enterSeedButton.textEntryPopup.gameObject.SetActive(true);
+                enterSeedButton.textEntryPopup.StartCoroutine(enterSeedButton.textEntryPopup.BackWhenBackButtonReleased());
+            };
+            enterSeedButton.textEntryPopup.gameObject.SetActive(false);
+            fileSlotPopup.Init(string.Empty);
+            fileSlotPopup.gameObject.SetActive(true);
+            fileSlotPopup.transform.SetParent(enterSeedButton.addedTo.transform.parent);
+            enterSeedButton.addedTo.gameObject.SetActive(false);
+            Canvas.ForceUpdateCanvases();
+            fileSlotPopup.initialSelection.GetComponent<UIObjectAudioHandler>().playAudio = false;
+            EventSystem.current.SetSelectedGameObject(fileSlotPopup.initialSelection);
+            fileSlotPopup.initialSelection.GetComponent<UIObjectAudioHandler>().playAudio = true;
+            return false;
+        }
+
         //On submit of rando file location
         bool OnEnterRandoFileSlot(string fileSlot)
         {
             Console.WriteLine($"Received file slot number: {fileSlot}");
 
-            int randoSaveSlot = Convert.ToInt32(fileSlot);
+            return SetSeedForFileSlot(Convert.ToInt32(fileSlot));
+        }
 
+        //Moved the seed setting logic out so I could reuse it.
+        bool SetSeedForFileSlot(int fileSlot, int seed = Int32.MinValue)
+        {
             //Check to make sure an apporiate save slot was chosen.
-            if (randoSaveSlot < 1 || randoSaveSlot > 3)
+            if (fileSlot < 1 || fileSlot > 3)
             {
-                Console.WriteLine($"User provided an invalid save slot number {randoSaveSlot}");
+                Console.WriteLine($"User provided an invalid save slot number {fileSlot}");
                 return false;
             }
 
-            //Generate a seed
-            Console.WriteLine("Generating seed...");
-            int seed = ItemRandomizerUtil.GenerateSeed();
-            Console.WriteLine($"Seed generated: '{seed}'");
-
+            if (seed == Int32.MinValue)
+            {
+                //Generate a seed
+                Console.WriteLine("Generating seed...");
+                seed = ItemRandomizerUtil.GenerateSeed();
+                Console.WriteLine($"Seed generated: '{seed}'");
+            }
             //Save this seed into the state
-            randoStateManager.AddSeed(randoSaveSlot, seed);
+            randoStateManager.AddSeed(fileSlot, seed);
 
+            Console.WriteLine($"Set seed '{seed}' to file slot '{fileSlot}'");
             return true;
         }
 
@@ -251,5 +296,7 @@ namespace MessengerRando
             //Load the HQ
             Manager<TowerOfTimeHQManager>.Instance.TeleportInToTHQ(true, ELevelEntranceID.ENTRANCE_A, null, null, true);
         }
+
+
     }
 }

--- a/RandomizedItemInserter.cs
+++ b/RandomizedItemInserter.cs
@@ -36,6 +36,7 @@ namespace MessengerRando
             //On.CutsceneHasPlayed.IsTrue += CutsceneHasPlayed_IsTrue;
             On.SaveGameSelectionScreen.OnLoadGame += SaveGameSelectionScreen_OnLoadGame;
             On.SaveGameSelectionScreen.OnNewGame += SaveGameSelectionScreen_OnNewGame;
+            On.PhantomEnemy.ReceiveHit += PhantomEnemy_ReceiveHit;
             
             Console.WriteLine("Randomizer finished loading!");
         }
@@ -163,6 +164,19 @@ namespace MessengerRando
             orig(self, slot);
         }
 
+        //Phantom damage function. 
+        bool PhantomEnemy_ReceiveHit(On.PhantomEnemy.orig_ReceiveHit orig, PhantomEnemy self, HitData hitData)
+        {
+            //We want phantom to not take damage if all notes have not been collected yet.
+            if(ItemRandomizerUtil.HasAllNotes())
+            {
+                return orig(self, hitData);
+            }
+            //Didn't get all the notes...so nothing will happen!!!
+            Console.WriteLine("I see you don't have all of the music notes...you thought you could damage phantom without them?!");
+            return false;
+        }
+
         /*TODO Maybe use later, for now will not take a file name
         //On submit of rando file name
         bool OnEnterRandoFileName(string fileName)
@@ -217,5 +231,7 @@ namespace MessengerRando
 
             return true;
         }
+
+
     }
 }

--- a/RandomizedItemInserter.cs
+++ b/RandomizedItemInserter.cs
@@ -14,6 +14,7 @@ namespace MessengerRando
         private RandomizerStateManager randoStateManager;       
 
         TextEntryButtonInfo generateSeedButton;
+        SubMenuButtonInfo teleportToHqButton;
 
         public override void Load()
         {
@@ -28,6 +29,9 @@ namespace MessengerRando
             //Add generate mod option button
             generateSeedButton = Courier.UI.RegisterTextEntryModOptionButton(() => "Generate Random Seed", OnEnterRandoFileSlot, 1, () => "Which save slot would you like to start a rando seed?", () => "1", CharsetFlags.Number);
             generateSeedButton.SaveMethod = new RandomizerSaveMethod(RANDO_OPTION_KEY);
+
+            //Add teleport to HQ button\
+            teleportToHqButton = Courier.UI.RegisterSubMenuModOptionButton(() => "Teleport to HQ", OnSelectTeleportToHq);
 
             //Plug in my code :3
             On.InventoryManager.AddItem += InventoryManager_AddItem;
@@ -45,6 +49,7 @@ namespace MessengerRando
         {
             //I only want the generate seed mod option available when not in the game.
             generateSeedButton.IsEnabled = () => Manager<LevelManager>.Instance.GetCurrentLevelEnum() == ELevel.NONE;
+            teleportToHqButton.IsEnabled = () => Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE;
         }
 
         void InventoryManager_AddItem(On.InventoryManager.orig_AddItem orig, InventoryManager self, EItems itemId, int quantity)
@@ -232,6 +237,19 @@ namespace MessengerRando
             return true;
         }
 
+        void OnSelectTeleportToHq()
+        {
+            //Properly close out of the mod options and get the game state back together
+            Manager<PauseManager>.Instance.Resume();
+            Manager<UIManager>.Instance.GetView<OptionScreen>().Close(false);                
+            Console.WriteLine("Teleporting to HQ!");
+            Courier.UI.ModOptionScreen.Close(false);
 
+            //Fade the music out because musiception is annoying
+            Manager<AudioManager>.Instance.FadeMusicVolume(1f, 0f, true);
+
+            //Load the HQ
+            Manager<TowerOfTimeHQManager>.Instance.TeleportInToTHQ(true, ELevelEntranceID.ENTRANCE_A, null, null, true);
+        }
     }
 }

--- a/Utils/ItemRandomizerUtil.cs
+++ b/Utils/ItemRandomizerUtil.cs
@@ -149,5 +149,20 @@ namespace MessengerRando
 
         }
         */
+
+        //Checks to see if all expected notes have already been collected
+        public static bool HasAllNotes()
+        {
+            if (Manager<InventoryManager>.Instance.GetItemQuantity(EItems.KEY_OF_CHAOS) > 0
+                && Manager<InventoryManager>.Instance.GetItemQuantity(EItems.KEY_OF_COURAGE) > 0
+                && Manager<InventoryManager>.Instance.GetItemQuantity(EItems.KEY_OF_HOPE) > 0
+                && Manager<InventoryManager>.Instance.GetItemQuantity(EItems.KEY_OF_LOVE) > 0
+                && Manager<InventoryManager>.Instance.GetItemQuantity(EItems.KEY_OF_STRENGTH) > 0
+                && Manager<InventoryManager>.Instance.GetItemQuantity(EItems.KEY_OF_SYMBIOSIS) > 0)
+            {
+                return true;
+            }
+            return false;
+        }
     }
 }

--- a/Utils/ItemRandomizerUtil.cs
+++ b/Utils/ItemRandomizerUtil.cs
@@ -19,7 +19,6 @@ namespace MessengerRando
 
         public static Dictionary<EItems,EItems> GenerateRandomizedMappings(int passedSeed = Int32.MinValue)
         {
-            Console.WriteLine("Beginning mapping generation.");
             //If no seed was provided, create one
             if(passedSeed == Int32.MinValue)
             {
@@ -46,6 +45,7 @@ namespace MessengerRando
             {
                 OfficialSeed = passedSeed;
             }
+            Console.WriteLine($"Beginning mapping generation for seed '{OfficialSeed}'.");
             //We now have a seed. Lets also create a local copy of the locations so I can mess with it without breaking stuff.
             List<EItems> locationsForGeneration = new List<EItems>(RandomizableLocations);
 

--- a/Utils/RandomizerStateManager.cs
+++ b/Utils/RandomizerStateManager.cs
@@ -7,12 +7,13 @@ namespace MessengerRando
     class RandomizerStateManager
     {
         public static RandomizerStateManager Instance { private set; get; }
-
         public Dictionary<EItems, EItems> CurrentLocationToItemMapping { set; get; }
-
+        public bool IsRandomizedFile { set; get; }
+        
         private Dictionary<int, int> seeds;
 
         private Dictionary<EItems, bool> noteCutsceneTriggerStates;
+
 
        public static void Initialize()
         {
@@ -84,6 +85,7 @@ namespace MessengerRando
         public void ResetCurrentLocationToItemMappings()
         {
             CurrentLocationToItemMapping = new Dictionary<EItems, EItems>();
+            this.IsRandomizedFile = false;
         }
 
         public bool IsNoteCutsceneTriggered(EItems note)

--- a/courier.toml
+++ b/courier.toml
@@ -1,0 +1,5 @@
+name = "TheMessengerRandomizer"
+version = "0.1"
+dependencies = [
+  { name = "Courier", version = "0.5.3" }
+]


### PR DESCRIPTION
RELEASE NOTES:

* Added mod metadata toml file, mod supported on Courier 0.5.3
* Phantom boss got a new rule. If you dont have all the notes, you cant damage him. 
	* This is to help maintain the spirit of randomizer. This rule will be adjusted as development continues.
* Added a new in game mod option to Teleport To HQ! 
	* A highly requested feature and something I kind of wish existed in the vanilla game sometimes. Now there is a button you can press that will teleport Ninja directly back to HQ so you can carry on with randomizer nonsense.
	* Please do not try to teleport during Boss fights/cutscenes or while already in the HQ or a shop. It won't end well for you I promise(I'll try to fix this in some way later).
* Added new main menu mod option to set seed for a file save
	* Yes! No more messing with Mod Option save files like a pleb. Do it in-game like a champ!