### PR TITLE
V0.2.3

### DIFF
--- a/RandomizedItemInserter.cs
+++ b/RandomizedItemInserter.cs
@@ -3,7 +3,6 @@ using MessengerRando.Overrides;
 using Mod.Courier;
 using Mod.Courier.Module;
 using Mod.Courier.UI;
-using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -16,10 +15,14 @@ namespace MessengerRando
     {
         private const string RANDO_OPTION_KEY = "minous27RandoSeeds";
 
+        // Placing version number here for now
+        private const string RANDO_VERISON = "v0.2.3";
+
         private RandomizerStateManager randoStateManager;       
 
         TextEntryButtonInfo generateSeedButton;
         TextEntryButtonInfo enterSeedButton;
+        SubMenuButtonInfo versionButton;
         SubMenuButtonInfo teleportToHqButton;
 
         public override void Load()
@@ -41,6 +44,9 @@ namespace MessengerRando
             //Add Set seed mod option button
             enterSeedButton = Courier.UI.RegisterTextEntryModOptionButton(() => "Set Randomizer Seed", OnEnterSeedNumber, 15, () => "What is the seed you would like to play?", null,  CharsetFlags.Number);
             generateSeedButton.SaveMethod = randomizerSaveMethod;
+
+            //Add Randomizer Version button
+            versionButton = Courier.UI.RegisterSubMenuModOptionButton(() => $"Randomizer Version: {RANDO_VERISON}", null);
 
             //Add teleport to HQ button\
             teleportToHqButton = Courier.UI.RegisterSubMenuModOptionButton(() => "Teleport to HQ", OnSelectTeleportToHq);
@@ -66,7 +72,11 @@ namespace MessengerRando
             generateSeedButton.IsEnabled = () => Manager<LevelManager>.Instance.GetCurrentLevelEnum() == ELevel.NONE;
             enterSeedButton.IsEnabled = () => Manager<LevelManager>.Instance.GetCurrentLevelEnum() == ELevel.NONE;
 
+            //Options I only want working while actually in the game
             teleportToHqButton.IsEnabled = () => Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE;
+
+            //Options always available
+            versionButton.IsEnabled = () => true;
         }
 
         void InventoryManager_AddItem(On.InventoryManager.orig_AddItem orig, InventoryManager self, EItems itemId, int quantity)

--- a/RandomizedItemInserter.cs
+++ b/RandomizedItemInserter.cs
@@ -81,8 +81,8 @@ namespace MessengerRando
 
             //Options I only want working while actually in the game
             windmillShurikenToggleButton.IsEnabled = () => (Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE && Manager<InventoryManager>.Instance.GetItemQuantity(EItems.WINDMILL_SHURIKEN) > 0);
-            teleportToHqButton.IsEnabled = () => Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE;
-            teleportToNinjaVillage.IsEnabled = () => (Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE && Manager<ProgressionManager>.Instance.HasCutscenePlayed("ElderAwardSeedCutscene")); 
+            teleportToHqButton.IsEnabled = () => (Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE && randoStateManager.IsSafeTeleportState());
+            teleportToNinjaVillage.IsEnabled = () => (Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE && Manager<ProgressionManager>.Instance.HasCutscenePlayed("ElderAwardSeedCutscene") && randoStateManager.IsSafeTeleportState()); 
 
             //Options always available
             versionButton.IsEnabled = () => true;
@@ -396,8 +396,7 @@ namespace MessengerRando
 
         void OnSelectTeleportToHq()
         {
-            Console.WriteLine(Manager<LevelManager>.Instance.GetCurrentLevelEnum());
-            /*
+
             //Properly close out of the mod options and get the game state back together
             Manager<PauseManager>.Instance.Resume();
             Manager<UIManager>.Instance.GetView<OptionScreen>().Close(false);                
@@ -408,8 +407,7 @@ namespace MessengerRando
             Manager<AudioManager>.Instance.FadeMusicVolume(1f, 0f, true);
 
             //Load the HQ
-            Manager<TowerOfTimeHQManager>.Instance.TeleportInToTHQ(true, ELevelEntranceID.ENTRANCE_A, null, null, true);\
-            */
+            Manager<TowerOfTimeHQManager>.Instance.TeleportInToTHQ(true, ELevelEntranceID.ENTRANCE_A, null, null, true);
         }
 
         void OnSelectTeleportToNinjaVillage()

--- a/RandomizedItemInserter.cs
+++ b/RandomizedItemInserter.cs
@@ -16,9 +16,6 @@ namespace MessengerRando
     {
         private const string RANDO_OPTION_KEY = "minous27RandoSeeds";
 
-        // Placing version number here for now
-        private const string RANDO_VERISON = "v0.2.3";
-
         private RandomizerStateManager randoStateManager;       
 
         TextEntryButtonInfo generateSeedButton;
@@ -40,6 +37,9 @@ namespace MessengerRando
             RandomizerSaveMethod randomizerSaveMethod = new RandomizerSaveMethod(RANDO_OPTION_KEY);
 
 
+            //Add Randomizer Version button
+            versionButton = Courier.UI.RegisterSubMenuModOptionButton(() => "Messenger Randomizer: v" + ItemRandomizerUtil.GetModVersion(), null);
+
             //Add generate mod option button
             generateSeedButton = Courier.UI.RegisterTextEntryModOptionButton(() => "Generate Random Seed", OnEnterRandoFileSlot, 1, () => "Which save slot would you like to start a rando seed?", () => "1", CharsetFlags.Number);
             generateSeedButton.SaveMethod = randomizerSaveMethod;
@@ -47,9 +47,6 @@ namespace MessengerRando
             //Add Set seed mod option button
             enterSeedButton = Courier.UI.RegisterTextEntryModOptionButton(() => "Set Randomizer Seed", OnEnterSeedNumber, 15, () => "What is the seed you would like to play?", null,  CharsetFlags.Number);
             generateSeedButton.SaveMethod = randomizerSaveMethod;
-
-            //Add Randomizer Version button
-            versionButton = Courier.UI.RegisterSubMenuModOptionButton(() => $"Randomizer Version: {RANDO_VERISON}", null);
 
             //Add windmill shuriken toggle button
             windmillShurikenToggleButton = Courier.UI.RegisterSubMenuModOptionButton(() => Manager<ProgressionManager>.Instance.useWindmillShuriken ? "Active Regular Shurikens" : "Active Windmill Shurikens", OnToggleWindmillShuriken);
@@ -399,6 +396,8 @@ namespace MessengerRando
 
         void OnSelectTeleportToHq()
         {
+            Console.WriteLine(Manager<LevelManager>.Instance.GetCurrentLevelEnum());
+            /*
             //Properly close out of the mod options and get the game state back together
             Manager<PauseManager>.Instance.Resume();
             Manager<UIManager>.Instance.GetView<OptionScreen>().Close(false);                
@@ -409,7 +408,8 @@ namespace MessengerRando
             Manager<AudioManager>.Instance.FadeMusicVolume(1f, 0f, true);
 
             //Load the HQ
-            Manager<TowerOfTimeHQManager>.Instance.TeleportInToTHQ(true, ELevelEntranceID.ENTRANCE_A, null, null, true);
+            Manager<TowerOfTimeHQManager>.Instance.TeleportInToTHQ(true, ELevelEntranceID.ENTRANCE_A, null, null, true);\
+            */
         }
 
         void OnSelectTeleportToNinjaVillage()

--- a/Utils/ItemRandomizerUtil.cs
+++ b/Utils/ItemRandomizerUtil.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using Mod.Courier;
+using Mod.Courier.Module;
 
 
 namespace MessengerRando
@@ -205,6 +207,22 @@ namespace MessengerRando
                 return true;
             }
             return false;
+        }
+
+        //Get the version number
+        public static string GetModVersion()
+        {
+            string version = "Unknown";
+            
+            foreach(CourierModuleMetadata modMetadata in Courier.Mods)
+            {
+                if("TheMessengerRandomizer".Equals(modMetadata.Name))
+                {
+                    version = modMetadata.VersionString;
+                }
+            }
+
+            return version;
         }
     }
 }

--- a/Utils/ItemRandomizerUtil.cs
+++ b/Utils/ItemRandomizerUtil.cs
@@ -70,6 +70,7 @@ namespace MessengerRando
         public static void Load()
         {
             LoadRandomizableItems();
+            LoadRandomizableLocations();
             LoadSpecialTriggerNames();
             LoadCutsceneMappings();
         }
@@ -88,22 +89,27 @@ namespace MessengerRando
             List<EItems> itemsToLoad = new List<EItems>();
             itemsToLoad.Add(EItems.WINGSUIT);
             itemsToLoad.Add(EItems.GRAPLOU);
-            itemsToLoad.Add(EItems.SEASHELL);
+            itemsToLoad.Add(EItems.MAGIC_BOOTS);
+            itemsToLoad.Add(EItems.WINDMILL_SHURIKEN);
             /*Making elder quest chain vanilla for now. Need to handle it's complex checks before i rando it.
             itemsToLoad.Add(EItems.TEA_SEED);
             */
-            itemsToLoad.Add(EItems.CANDLE);
+
             itemsToLoad.Add(EItems.POWER_THISTLE);
             itemsToLoad.Add(EItems.FAIRY_BOTTLE);
             itemsToLoad.Add(EItems.SUN_CREST);
             itemsToLoad.Add(EItems.MOON_CREST);
-            itemsToLoad.Add(EItems.MAGIC_BOOTS);
             itemsToLoad.Add(EItems.RUXXTIN_AMULET);
+            itemsToLoad.Add(EItems.DEMON_KING_CROWN);
+
+            itemsToLoad.Add(EItems.CANDLE);
+            itemsToLoad.Add(EItems.SEASHELL);
+
             itemsToLoad.Add(EItems.NECROPHOBIC_WORKER);
             itemsToLoad.Add(EItems.CLAUSTROPHOBIC_WORKER);
             itemsToLoad.Add(EItems.PYROPHOBIC_WORKER);
             itemsToLoad.Add(EItems.ACROPHOBIC_WORKER);
-            itemsToLoad.Add(EItems.DEMON_KING_CROWN);
+
             itemsToLoad.Add(EItems.KEY_OF_CHAOS);
             itemsToLoad.Add(EItems.KEY_OF_COURAGE);
             itemsToLoad.Add(EItems.KEY_OF_HOPE);
@@ -112,9 +118,40 @@ namespace MessengerRando
             itemsToLoad.Add(EItems.KEY_OF_SYMBIOSIS);
 
             RandomizableItems = itemsToLoad;
-            //For now the lists will be the same so lets set the locations as well.
-            RandomizableLocations = new List<EItems>(itemsToLoad);
+        }
 
+        private static void LoadRandomizableLocations()
+        {
+            List<EItems> locationsToLoad = new List<EItems>();
+            
+            locationsToLoad.Add(EItems.WINGSUIT);
+            locationsToLoad.Add(EItems.GRAPLOU);
+            locationsToLoad.Add(EItems.MAGIC_BOOTS);
+            locationsToLoad.Add(EItems.CLIMBING_CLAWS);
+
+            locationsToLoad.Add(EItems.POWER_THISTLE);
+            locationsToLoad.Add(EItems.FAIRY_BOTTLE);
+            locationsToLoad.Add(EItems.SUN_CREST);
+            locationsToLoad.Add(EItems.MOON_CREST);
+            locationsToLoad.Add(EItems.RUXXTIN_AMULET);
+            locationsToLoad.Add(EItems.DEMON_KING_CROWN);
+
+            locationsToLoad.Add(EItems.CANDLE);
+            locationsToLoad.Add(EItems.SEASHELL);
+
+            locationsToLoad.Add(EItems.NECROPHOBIC_WORKER);
+            locationsToLoad.Add(EItems.CLAUSTROPHOBIC_WORKER);
+            locationsToLoad.Add(EItems.PYROPHOBIC_WORKER);
+            locationsToLoad.Add(EItems.ACROPHOBIC_WORKER);
+
+            locationsToLoad.Add(EItems.KEY_OF_CHAOS);
+            locationsToLoad.Add(EItems.KEY_OF_COURAGE);
+            locationsToLoad.Add(EItems.KEY_OF_HOPE);
+            locationsToLoad.Add(EItems.KEY_OF_LOVE);
+            locationsToLoad.Add(EItems.KEY_OF_STRENGTH);
+            locationsToLoad.Add(EItems.KEY_OF_SYMBIOSIS);
+
+            RandomizableLocations = locationsToLoad;
         }
 
         private static void LoadSpecialTriggerNames()

--- a/Utils/RandomizerStateManager.cs
+++ b/Utils/RandomizerStateManager.cs
@@ -98,5 +98,14 @@ namespace MessengerRando
             this.noteCutsceneTriggerStates[note] = true;
         }
 
+        public bool IsSafeTeleportState()
+        {
+            //Unsafe teleport states are shops/hq/boss fights
+
+            //Manager<LevelManager>.Instance.CurrentSceneName
+            
+            return true;
+        }
+
     }
 }

--- a/Utils/RandomizerStateManager.cs
+++ b/Utils/RandomizerStateManager.cs
@@ -101,10 +101,18 @@ namespace MessengerRando
         public bool IsSafeTeleportState()
         {
             //Unsafe teleport states are shops/hq/boss fights
+            bool isTeleportSafe = true;
 
-            //Manager<LevelManager>.Instance.CurrentSceneName
-            
-            return true;
+            Console.WriteLine($"In ToT HQ: {Manager<TotHQ>.Instance.root.gameObject.activeInHierarchy}");
+            Console.WriteLine($"In Shop: {Manager<Shop>.Instance.gameObject.activeInHierarchy}");
+
+            //ToT HQ or Shop
+            if (Manager<TotHQ>.Instance.root.gameObject.activeInHierarchy || Manager<Shop>.Instance.gameObject.activeInHierarchy)
+            {
+                isTeleportSafe = false;
+            }
+
+            return isTeleportSafe;
         }
 
     }

--- a/courier.toml
+++ b/courier.toml
@@ -1,5 +1,5 @@
 name = "TheMessengerRandomizer"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
-  { name = "Courier", version = "0.6.0" }
+  { name = "Courier", version = "0.6.4" }
 ]


### PR DESCRIPTION
Added new functionality for the randomizer:

* Added Windmill Shuriken to the mix!
    * You asked for it? You got it! I have added Windmill Shuriken into the list of items you can find on your rando adventures!
    * For now the Windmill Shuriken chest itself does nothing special, just lets you switch between shurikens like is use to if you (for some reason) go get all the seals.
    * "But Minous, how do I switch without the chest" I hear you ask? [Check the wiki!](https://github.com/minous27/TheMessengerRandomizerMod/wiki#active-regularwindmill-shurikens)
* Climbing Claws check is **LIVE**
    * In order to support this I also turned on the Climbing Claws check. There is an item there now so...get it. Or not, whatever.
* Teleport to Ninja Village function added!
    * Nobody likes doing old man chain, running all the way back to Ninja Village multiple times is lame. So we sped that up! [More info in the wiki!](https://github.com/minous27/TheMessengerRandomizerMod/wiki#teleport-to-hqninja-village)
* Added Rando mod version number to the mod options
    * This will give us more insight into what version of the randomizer you have installed. Useful for troubleshooting and for races to make sure everyone is on the same version.
* Also a bug fix!
    * Added validations for teleporting - this means that you can no longer use the teleport functions while in the HQ or a Shop. You shouldn't have been already but if you did then weird things happened...so I helped a bit with that.