### PR TITLE
v0.4.1 Update

### DIFF
--- a/RandomizerMain.cs
+++ b/RandomizerMain.cs
@@ -81,6 +81,7 @@ namespace MessengerRando
             IL.RuxxtinNoteAndAwardAmuletCutscene.Play += RuxxtinNoteAndAwardAmuletCutscene_Play;
             On.CatacombLevelInitializer.OnBeforeInitDone += CatacombLevelInitializer_OnBeforeInitDone;
             On.DialogManager.LoadDialogs_ELanguage += DialogChanger.LoadDialogs_Elanguage;
+            On.UpgradeButtonData.IsStoryUnlocked += UpgradeButtonData_IsStoryUnlocked;
             //temp add
             On.PowerSeal.OnEnterRoom += PowerSeal_OnEnterRoom;
             On.DialogSequence.GetDialogList += DialogSequence_GetDialogList;
@@ -458,6 +459,27 @@ namespace MessengerRando
                 cursor.EmitDelegate<Func<EItems, EItems>>(GetRandoItemByItem);
             }
             
+        }
+
+        bool UpgradeButtonData_IsStoryUnlocked(On.UpgradeButtonData.orig_IsStoryUnlocked orig, UpgradeButtonData self)
+        {
+            bool isUnlocked;
+
+            //Checking if this particular upgrade is the glide attack
+            if(EShopUpgradeID.GLIDE_ATTACK.Equals(self.upgradeID))
+            {
+                //Unlock the glide attack (no need to keep it hidden, player can just buy it whenever they want.
+                isUnlocked = true;
+            }
+            else
+            {
+                isUnlocked = orig(self);
+            }
+
+            //I think there is where I can catch things like checks for the wingsuit attack upgrade.
+            Console.WriteLine($"Checking upgrade '{self.upgradeID}'. Is story unlocked: {isUnlocked}");
+
+            return isUnlocked;
         }
 
         /*TODO Maybe use later, for now will not take a file name

--- a/RandomizerMain.cs
+++ b/RandomizerMain.cs
@@ -28,6 +28,7 @@ namespace MessengerRando
         TextEntryButtonInfo loadRandomizerFileForFileSlotButton;
   
         SubMenuButtonInfo versionButton;
+        SubMenuButtonInfo seedNumButton;
 
         SubMenuButtonInfo windmillShurikenToggleButton;
         SubMenuButtonInfo teleportToHqButton;
@@ -50,6 +51,9 @@ namespace MessengerRando
 
             //Add Randomizer Version button
             versionButton = Courier.UI.RegisterSubMenuModOptionButton(() => "Messenger Randomizer: v" + ItemRandomizerUtil.GetModVersion(), null);
+
+            //Add current seed number button
+            seedNumButton = Courier.UI.RegisterSubMenuModOptionButton(() => "Current seed number: " + GetCurrentSeedNum(), null);
 
             //Add load seed file button
             loadRandomizerFileForFileSlotButton = Courier.UI.RegisterTextEntryModOptionButton(() => "Load Randomizer File For File Slot", (entry) => OnEnterFileSlot(entry), 1, () => "Which save slot would you like to start a rando seed?(1/2/3)", () => "1", CharsetFlags.Number);
@@ -92,7 +96,8 @@ namespace MessengerRando
             //Options I only want working while actually in the game
             windmillShurikenToggleButton.IsEnabled = () => (Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE && Manager<InventoryManager>.Instance.GetItemQuantity(EItems.WINDMILL_SHURIKEN) > 0);
             teleportToHqButton.IsEnabled = () => (Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE && randoStateManager.IsSafeTeleportState());
-            teleportToNinjaVillage.IsEnabled = () => (Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE && Manager<ProgressionManager>.Instance.HasCutscenePlayed("ElderAwardSeedCutscene") && randoStateManager.IsSafeTeleportState()); 
+            teleportToNinjaVillage.IsEnabled = () => (Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE && Manager<ProgressionManager>.Instance.HasCutscenePlayed("ElderAwardSeedCutscene") && randoStateManager.IsSafeTeleportState());
+            seedNumButton.IsEnabled = () => (Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE);
 
             //Options always available
             versionButton.IsEnabled = () => true;
@@ -374,11 +379,6 @@ namespace MessengerRando
                
                 //Load mappings
                 randoStateManager.CurrentLocationToItemMapping = ItemRandomizerUtil.ParseLocationToItemMappings(randoStateManager.GetSeedForFileSlot(fileSlot));
-
-                //for now, only turn on dialog mappings for basic seeds
-                SettingValue currentDifficultySetting = SettingValue.Advanced;
-                randoStateManager.GetSeedForFileSlot(fileSlot).Settings.TryGetValue(SettingType.Difficulty, out currentDifficultySetting);
-
                 randoStateManager.CurrentLocationDialogtoRandomDialogMapping = DialogChanger.GenerateDialogMappingforItems();
 
                 randoStateManager.IsRandomizedFile = true;
@@ -599,6 +599,18 @@ namespace MessengerRando
                 return item;
             }
             
+        }
+
+        private string GetCurrentSeedNum()
+        {
+            string seedNum = "Unknown";
+
+            if(randoStateManager != null && randoStateManager.GetSeedForFileSlot(randoStateManager.CurrentFileSlot).Seed > 0)
+            {
+                seedNum = randoStateManager.GetSeedForFileSlot(randoStateManager.CurrentFileSlot).Seed.ToString();
+            }
+
+            return seedNum;
         }
     }
 }

--- a/RandomizerMain.cs
+++ b/RandomizerMain.cs
@@ -378,13 +378,9 @@ namespace MessengerRando
                 //for now, only turn on dialog mappings for basic seeds
                 SettingValue currentDifficultySetting = SettingValue.Advanced;
                 randoStateManager.GetSeedForFileSlot(fileSlot).Settings.TryGetValue(SettingType.Difficulty, out currentDifficultySetting);
-                
-                //Currently only doing dialog mapping for basic seeds.
-                if (currentDifficultySetting.Equals(SettingValue.Basic))
-                {
-                    randoStateManager.CurrentLocationDialogtoRandomDialogMapping = DialogChanger.GenerateDialogMappingforItems();
-                }
- 
+
+                randoStateManager.CurrentLocationDialogtoRandomDialogMapping = DialogChanger.GenerateDialogMappingforItems();
+
                 randoStateManager.IsRandomizedFile = true;
                 randoStateManager.CurrentFileSlot = fileSlot;
                 //Log spoiler log

--- a/Utils/DialogChanger.cs
+++ b/Utils/DialogChanger.cs
@@ -47,6 +47,9 @@ namespace MessengerRando.Utils
             itemDialogID.Add(EItems.NECROPHOBIC_WORKER, "NECRO_PHOBEKIN_DIALOG");
             itemDialogID.Add(EItems.CLAUSTROPHOBIC_WORKER, "FIND_CLAUSTRO");
 
+            //Trying out timeshard
+            itemDialogID.Add(EItems.TIME_SHARD, "AWARD_TIMESHARD");
+
             return itemDialogID;
         }
 
@@ -73,9 +76,9 @@ namespace MessengerRando.Utils
         public static Dictionary<string, string> GenerateDialogMappingforItems()
         {
             Dictionary<string, string> dialogmap = new Dictionary<string, string>();
-            Dictionary<EItems, string> ItemtoDialogIDMap = GetDialogIDtoItems();
+            Dictionary<EItems, string> itemToDialogIDMap = GetDialogIDtoItems();
             Dictionary<LocationRO, RandoItemRO> current = RandomizerStateManager.Instance.CurrentLocationToItemMapping;
-
+            /* OLD
             foreach (KeyValuePair<LocationRO, RandoItemRO> KVP in current)
             {
                 Console.WriteLine($"Dialog mapping -- {KVP.Key.PrettyLocationName}");
@@ -88,6 +91,22 @@ namespace MessengerRando.Utils
                     Console.WriteLine($"We mapped item dialog {ItemtoDialogIDMap[ItemActuallyFound.Item]} to the location {ItemtoDialogIDMap[LocationChecked]}");
                 }
             }
+            */
+            
+            //I am gonna keep the mappings limited to basic locations since the advanced locations are handled by another process.
+            foreach(LocationRO location in RandomizerConstants.GetRandoLocationList())
+            {
+                Console.WriteLine($"Dialog mapping -- {location.PrettyLocationName}");
+                EItems locationChecked = (EItems)Enum.Parse(typeof(EItems),location.PrettyLocationName);
+                RandoItemRO itemActuallyFound = current[location];
+                
+                if(itemToDialogIDMap.ContainsKey(locationChecked) && itemToDialogIDMap.ContainsKey(itemActuallyFound.Item))
+                {
+                    dialogmap.Add(itemToDialogIDMap[locationChecked], itemToDialogIDMap[itemActuallyFound.Item]);
+                    Console.WriteLine($"We mapped item dialog {itemToDialogIDMap[itemActuallyFound.Item]} to the location {itemToDialogIDMap[locationChecked]}");
+                }
+            }
+
             return dialogmap;
         }
 
@@ -139,7 +158,18 @@ namespace MessengerRando.Utils
                     if (dialogMap.ContainsKey(tobereplacedKey))
                     {
                         //Replaces the entire dialog
-                        LocCopy[tobereplacedKey] = Loc[replacewithKey];
+                        if("AWARD_TIMESHARD".Equals(replacewithKey))
+                        {
+                            //Timeshards don't have their own dialog. Gonna try to fake it.
+                            DialogInfo timeShardDialog = new DialogInfo();
+                            timeShardDialog.text = "Got a timeshard for your troubles.";
+                            LocCopy[tobereplacedKey] = new List<DialogInfo>();
+                            LocCopy[tobereplacedKey].Add(timeShardDialog);
+                        }
+                        else
+                        {
+                            LocCopy[tobereplacedKey] = Loc[replacewithKey];
+                        }
 
                         //Sets them to be all center and no portrait (This really only applies to phobekins but was 
                         LocCopy[tobereplacedKey][0].autoClose = false;

--- a/Utils/RandomizerConstants.cs
+++ b/Utils/RandomizerConstants.cs
@@ -158,8 +158,8 @@ namespace MessengerRando.Utils
             advancedRandomizedLocations.Add(new LocationRO("172236-44-28", "Bamboo Creek Seal - Spike ball pits", new EItems[] { EItems.NONE }, true, false, false)); //Spike ball pits
             advancedRandomizedLocations.Add(new LocationRO("300332-1236", "Bamboo Creek Seal - Spike crushers and Doors v2", new EItems[] { EItems.NONE }, true, false, false)); //Spike crushers and doors v2
             //Howling Grotto
-            advancedRandomizedLocations.Add(new LocationRO("108140-28-12", "Howling Grotto Seal - Windy Saws and Balls", new EItems[] { EItems.NONE }, false, false, false)); //Windy Saws and Balls
-            advancedRandomizedLocations.Add(new LocationRO("300332-92-76", "Howling Grotto Seal - Crushing Pits", new EItems[] { EItems.NONE }, false, false, false)); //Crushing Pits
+            advancedRandomizedLocations.Add(new LocationRO("108140-28-12", "Howling Grotto Seal - Windy Saws and Balls", new EItems[] { EItems.NONE }, true, false, false)); //Windy Saws and Balls *Use to be free, might still be in a Hard mode?*
+            advancedRandomizedLocations.Add(new LocationRO("300332-92-76", "Howling Grotto Seal - Crushing Pits", new EItems[] { EItems.NONE }, true, true, false)); //Crushing Pits *Use to be free, might still be in a Hard mode?*
             advancedRandomizedLocations.Add(new LocationRO("460492-172-156", "Howling Grotto Seal - Breezy Crushers", new EItems[] { EItems.NONE }, false, false, false)); //Breezy Crushers
             //Quillshroom Marsh
             advancedRandomizedLocations.Add(new LocationRO("204236-28-12", "Quillshroom Marsh Seal - Spikey Window", new EItems[] { EItems.NONE }, false, false, false)); //Spikey Window

--- a/courier.toml
+++ b/courier.toml
@@ -1,5 +1,5 @@
 name = "TheMessengerRandomizer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
   { name = "Courier", version = "0.7.0" }
 ]


### PR DESCRIPTION
The update contains a fix for the dialog replacements so advanced seeds can have the replacements as well.

## Advanced Dialog Fixes
The dialog replacements in v0.4.0 worked but didn't support advanced seeds and the trash items it introduced. This release will fix that.

## Seed number in Mod Options window
A nice update I snuck in there was to add the seed number of the current seed you are playing to the mod options window. Now people can confirm that the seed number they are playing is indeed the one they generated and can share that number with whoever so they can generate that mapping as well.

## Mapping logic updates
The following changes were made to the advanced seed placement logic.
- Howling Grotto Seal - Windy Saws and Balls
  - Updated to require wingsuit0
- Howling Grotto Seal - Crushing Pits
  - Updated to require wingsuit and rope dart