### PR TITLE
Ensure a boss room is actually a boss room

### DIFF
--- a/Archipelago/ArchipelagoClient.cs
+++ b/Archipelago/ArchipelagoClient.cs
@@ -8,7 +8,6 @@ using Archipelago.MultiClient.Net.Enums;
 using Archipelago.MultiClient.Net.Helpers;
 using Archipelago.MultiClient.Net.Packets;
 using MessengerRando.GameOverrideManagers;
-using MessengerRando.Utils;
 using Mod.Courier.UI;
 using Newtonsoft.Json;
 using static Mod.Courier.UI.TextEntryButtonInfo;
@@ -136,9 +135,9 @@ namespace MessengerRando.Archipelago
                 {
                     var bossMap = JsonConvert.DeserializeObject<Dictionary<string, string>>(bosses.ToString());
                     Console.WriteLine("Bosses:");
-                    foreach (var VARIABLE in bossMap)
+                    foreach (var bossPair in bossMap)
                     {
-                        Console.WriteLine($"{VARIABLE.Key}: {VARIABLE.Value}");
+                        Console.WriteLine($"{bossPair.Key}: {bossPair.Value}");
                     }
                     try
                     {
@@ -245,7 +244,7 @@ namespace MessengerRando.Archipelago
                 receivedItem.name = Session.Items.GetItemName(currentItemId);
                 receivedItem.choices = new List<DialogSequenceChoice>();
                 AwardItemPopupParams receivedItemParams = new AwardItemPopupParams(receivedItem, true);
-                Manager<UIManager>.Instance.ShowView<AwardItemPopup>(EScreenLayers.PROMPT, receivedItemParams, true);
+                Manager<UIManager>.Instance.ShowView<AwardItemPopup>(EScreenLayers.PROMPT, receivedItemParams);
             }
         }
 
@@ -296,22 +295,18 @@ namespace MessengerRando.Archipelago
             return false;
         }
 
-        private static int GetHintCost()
+        public static int GetHintCost()
         {
-            var hintCost = Session.RoomState.HintCost;
-            if (hintCost <= 0) return hintCost;
-            int locationCount = RandomizerConstants.GetRandoLocationList().Count();
-            if (SettingValue.Basic.Equals(ServerData.GameSettings[SettingType.Difficulty]))
+            var hintPercent = Session.RoomState.HintCostPercentage;
+            Console.WriteLine($"hintPercent {hintPercent}");
+            if (hintPercent > 0)
             {
-                hintCost = locationCount / hintCost;
+                var totalLocations = Session.Locations.AllLocations.Count;
+                hintPercent = (int)Math.Round(totalLocations * (hintPercent * 0.01));
             }
-            else
-            {
-                locationCount += RandomizerConstants.GetAdvancedRandoLocationList().Count();
-                hintCost = locationCount / hintCost;
-            }
-            return hintCost;
+            return hintPercent;
         }
+
 
         public static bool CanHint()
         {

--- a/Archipelago/ArchipelagoClient.cs
+++ b/Archipelago/ArchipelagoClient.cs
@@ -251,9 +251,7 @@ namespace MessengerRando.Archipelago
         public static void UpdateClientStatus(ArchipelagoClientState newState)
         {
             Console.WriteLine($"Updating client status to {newState}");
-            var statusUpdatePacket = new StatusUpdatePacket() { Status = newState };
-            if (ArchipelagoClientState.ClientGoal.Equals(newState))
-                Session.DataStorage[Scope.Slot, "HasFinished"] = true;
+            var statusUpdatePacket = new StatusUpdatePacket { Status = newState };
             Session.Socket.SendPacket(statusUpdatePacket);
         }
 

--- a/Archipelago/ArchipelagoClient.cs
+++ b/Archipelago/ArchipelagoClient.cs
@@ -298,7 +298,6 @@ namespace MessengerRando.Archipelago
         public static int GetHintCost()
         {
             var hintPercent = Session.RoomState.HintCostPercentage;
-            Console.WriteLine($"hintPercent {hintPercent}");
             if (hintPercent > 0)
             {
                 var totalLocations = Session.Locations.AllLocations.Count;

--- a/Archipelago/ArchipelagoData.cs
+++ b/Archipelago/ArchipelagoData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using MessengerRando.GameOverrideManagers;
 using MessengerRando.RO;
 using MessengerRando.Utils;
 using Newtonsoft.Json;
@@ -215,6 +216,7 @@ namespace MessengerRando.Archipelago
                 //Attempt to connect to the server and save the new data
                 ArchipelagoClient.ConnectAsync();
                 if (!ArchipelagoClient.Authenticated) ItemsAndLocationsHandler.Initialize();
+                RandoBossManager.DefeatedBosses.AddRange(tempServerData.DefeatedBosses);
                 return ArchipelagoClient.HasConnected = true; //Doing this here because of race conditions and the actual connection being threaded
             }
             catch (Exception ex) 

--- a/GameOverrideManagers/RandoBossManager.cs
+++ b/GameOverrideManagers/RandoBossManager.cs
@@ -148,6 +148,8 @@ namespace MessengerRando.GameOverrideManagers
                 RandoLevelManager.TeleportInArea(newPosition.BossRegion, newPosition.PlayerPosition,
                     newPosition.PlayerDimension);
             }
+            if (RandomizerStateManager.Instance.DefeatedBosses == null)
+                RandomizerStateManager.Instance.DefeatedBosses = new Dictionary<int, List<string>>();
             RandomizerStateManager.Instance.DefeatedBosses[RandomizerStateManager.Instance.CurrentFileSlot] =
                 DefeatedBosses;
         }

--- a/GameOverrideManagers/RandoBossManager.cs
+++ b/GameOverrideManagers/RandoBossManager.cs
@@ -42,6 +42,7 @@ namespace MessengerRando.GameOverrideManagers
             "DemonGeneral",
             "DemonArtificier",
             "ButterflyMatriarch",
+            "ClockworkConcierge",
             "Phantom"
         };
 

--- a/GameOverrideManagers/RandoBossManager.cs
+++ b/GameOverrideManagers/RandoBossManager.cs
@@ -10,7 +10,7 @@ namespace MessengerRando.GameOverrideManagers
     public class RandoBossManager
     {
         public RandoBossManager Instance;
-        private static readonly List<string> defeatedBosses = new List<string>();
+        public static readonly List<string> DefeatedBosses = new List<string>();
         private Dictionary<string, string> origToNewBoss;
         private static bool BossOverride;
 
@@ -127,7 +127,7 @@ namespace MessengerRando.GameOverrideManagers
                 bossName = RandomizerStateManager.Instance.BossManager.origToNewBoss
                     .First(name => name.Value.Equals(bossName)).Key;
             Console.WriteLine($"Checking if {bossName} is defeated.");
-            return !vanillaBossNames.Contains(bossName) || defeatedBosses.Contains(bossName);
+            return !vanillaBossNames.Contains(bossName) || DefeatedBosses.Contains(bossName);
         }
 
         public static void SetBossAsDefeated(string bossName)
@@ -138,7 +138,7 @@ namespace MessengerRando.GameOverrideManagers
                 BossOverride = false;
             }
             if (ArchipelagoClient.HasConnected) ArchipelagoClient.ServerData.DefeatedBosses.Add(bossName);
-            defeatedBosses.Add(bossName);
+            DefeatedBosses.Add(bossName);
             if (RandomizerStateManager.Instance.BossManager != null)
             {
                 var newPosition = bossLocations[bossName];

--- a/GameOverrideManagers/RandoBossManager.cs
+++ b/GameOverrideManagers/RandoBossManager.cs
@@ -10,7 +10,9 @@ namespace MessengerRando.GameOverrideManagers
     public class RandoBossManager
     {
         public RandoBossManager Instance;
-        public static readonly List<string> DefeatedBosses = new List<string>();
+
+        public static List<string> DefeatedBosses = new List<string>();
+
         private Dictionary<string, string> origToNewBoss;
         private static bool BossOverride;
 
@@ -146,6 +148,8 @@ namespace MessengerRando.GameOverrideManagers
                 RandoLevelManager.TeleportInArea(newPosition.BossRegion, newPosition.PlayerPosition,
                     newPosition.PlayerDimension);
             }
+            RandomizerStateManager.Instance.DefeatedBosses[RandomizerStateManager.Instance.CurrentFileSlot] =
+                DefeatedBosses;
         }
 
         public static bool ShouldFightBoss(string newRoomKey)

--- a/GameOverrideManagers/RandoBossManager.cs
+++ b/GameOverrideManagers/RandoBossManager.cs
@@ -151,9 +151,11 @@ namespace MessengerRando.GameOverrideManagers
         public static bool ShouldFightBoss(string newRoomKey)
         {
             if (!BossRoomKeys.Contains(newRoomKey) || BossOverride) return false;
+            var currentLevel = Manager<LevelManager>.Instance.GetCurrentLevelEnum();
             var bossName = GetVanillaBoss(newRoomKey);
             Console.WriteLine($"Entered {bossName}'s room. Has Defeated: {HasBossDefeated(bossName)}");
-            if (HasBossDefeated(bossName)) return false;
+            if (HasBossDefeated(bossName) || !currentLevel.Equals(bossLocations[bossName].BossRegion)) return false;
+            
             var teleporting = RandomizerStateManager.Instance.BossManager != null;
             Console.WriteLine($"Should teleport: {teleporting}");
             if (teleporting)

--- a/MessengerRando.csproj
+++ b/MessengerRando.csproj
@@ -35,8 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Archipelago.MultiClient.Net, Version=4.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Archipelago.MultiClient.Net.4.2.1\lib\net35\Archipelago.MultiClient.Net.dll</HintPath>
+    <Reference Include="Archipelago.MultiClient.Net, Version=4.2.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Archipelago.MultiClient.Net.4.2.4\lib\net35\Archipelago.MultiClient.Net.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>..\..\..\..\..\Steam\steamapps\common\The Messenger\TheMessenger_Data\Managed\Assembly-CSharp.dll</HintPath>
@@ -59,7 +59,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\Archipelago.MultiClient.Net.4.2.1\lib\net35\Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\Archipelago.MultiClient.Net.4.2.4\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
       <HintPath>..\..\..\..\..\Steam\steamapps\common\The Messenger\TheMessenger_Data\Managed\UnityEngine.dll</HintPath>
@@ -82,7 +82,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="websocket-sharp, Version=1.0.2.34775, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
-      <HintPath>packages\Archipelago.MultiClient.Net.4.2.1\lib\net35\websocket-sharp.dll</HintPath>
+      <HintPath>packages\Archipelago.MultiClient.Net.4.2.4\lib\net35\websocket-sharp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -113,6 +113,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="courier.toml"><CopyToOutputDirectory>Always</CopyToOutputDirectory></Content>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/RandomizerMain.cs
+++ b/RandomizerMain.cs
@@ -631,7 +631,9 @@ namespace MessengerRando
                 else if (randoStateManager.HasSeedForFileSlot(fileSlot))
                 {
                     //There's a valid seed and mapping available and Archipelago isn't involved
-                    randoStateManager.CurrentLocationToItemMapping = ItemRandomizerUtil.ParseLocationToItemMappings(randoStateManager.GetSeedForFileSlot(fileSlot));
+                    randoStateManager.CurrentLocationToItemMapping =
+                        ItemRandomizerUtil.ParseLocationToItemMappings(randoStateManager.GetSeedForFileSlot(fileSlot));
+                    RandoBossManager.DefeatedBosses = randoStateManager.DefeatedBosses[fileSlot];
                 }
             }
             catch (Exception e)

--- a/RandomizerMain.cs
+++ b/RandomizerMain.cs
@@ -622,6 +622,8 @@ namespace MessengerRando
                 }
                 else if (ArchipelagoClient.Authenticated && Manager<SaveManager>.Instance.GetSaveSlot(slotIndex).SecondsPlayed <= 100)
                 {
+                    randoStateManager.ResetRandomizerState();
+                    randoStateManager.ResetSeedForFileSlot(fileSlot);
                     //Hopefully this ensures this is a clean rando slot so the player doesn't just connect with an invalid slot
                     randoStateManager.AddSeed(ArchipelagoClient.ServerData.StartNewSeed(fileSlot));
                     randoStateManager.CurrentLocationToItemMapping = ArchipelagoClient.ServerData.LocationToItemMapping;

--- a/RandomizerMain.cs
+++ b/RandomizerMain.cs
@@ -30,6 +30,7 @@ namespace MessengerRando
         private const int MAX_BEATABLE_SEED_ATTEMPTS = 1;
 
         private float updateTimer;
+        private float updateTime = 3.0f;
 
         private RandomizerStateManager randoStateManager;
         private RandomizerSaveMethod randomizerSaveMethod;
@@ -56,6 +57,7 @@ namespace MessengerRando
         SubMenuButtonInfo archipelagoToggleMessagesButton;
         SubMenuButtonInfo archipelagoStatusButton;
         SubMenuButtonInfo archipelagoDeathLinkButton;
+        SubMenuButtonInfo archipelagoMessageTimerButton;
 
         private TextMeshProUGUI apTextDisplay8;
         private TextMeshProUGUI apTextDisplay16;
@@ -127,6 +129,9 @@ namespace MessengerRando
             
             //Add Archipelago message button
             archipelagoToggleMessagesButton = Courier.UI.RegisterSubMenuModOptionButton(() => ArchipelagoClient.DisplayAPMessages ? "Hide server messages" : "Display server messages", OnToggleAPMessages);
+            
+            //Add Archipelago message display timer button
+            archipelagoMessageTimerButton = Courier.UI.RegisterTextEntryModOptionButton(() => "AP Message Display Time", entry => OnSelectMessageTimer(entry), 1, () => "Enter amount of time to display Archipelago messages, in seconds", () => updateTime.ToString(), CharsetFlags.Number);
 
             //Add Archipelago death link button
             archipelagoDeathLinkButton = Courier.UI.RegisterSubMenuModOptionButton(() => ArchipelagoData.DeathLink ? "Disable Death Link" : "Enable Death Link", OnToggleDeathLink);
@@ -202,6 +207,7 @@ namespace MessengerRando
             archipelagoToggleMessagesButton.IsEnabled = () => ArchipelagoClient.Authenticated;
             archipelagoStatusButton.IsEnabled = () => ArchipelagoClient.Authenticated;
             archipelagoDeathLinkButton.IsEnabled = () => ArchipelagoClient.Authenticated;
+            archipelagoMessageTimerButton.IsEnabled = () => ArchipelagoClient.DisplayStatus;
 
             //Options I only want working while actually in the game
             windmillShurikenToggleButton.IsEnabled = () => (Manager<LevelManager>.Instance.GetCurrentLevelEnum() != ELevel.NONE && Manager<InventoryManager>.Instance.GetItemQuantity(EItems.WINDMILL_SHURIKEN) > 0);
@@ -1054,6 +1060,15 @@ namespace MessengerRando
             ArchipelagoData.DeathLink = !ArchipelagoData.DeathLink;
         }
 
+        bool OnSelectMessageTimer(string answer)
+        {
+            if (answer == null) return true;
+            if (ArchipelagoClient.ServerData == null) ArchipelagoClient.ServerData = new ArchipelagoData();
+            int.TryParse(answer, out var newTime);
+            updateTimer = newTime;
+            return true;
+        }
+
         /// <summary>
         /// Delegate function for getting rando item. This can be used by IL hooks that need to make this call later.
         /// </summary>
@@ -1114,7 +1129,6 @@ namespace MessengerRando
             if (randoStateManager.IsSafeTeleportState() && !Manager<PauseManager>.Instance.IsPaused)
                 ArchipelagoClient.DeathLinkHandler.KillPlayer();
             //This updates every {updateTime} seconds
-            float updateTime = 3.0f;
             updateTimer += Time.deltaTime;
             if (!(updateTimer >= updateTime)) return;
             apMessagesDisplay16.text = apMessagesDisplay8.text = ArchipelagoClient.UpdateMessagesText();

--- a/RandomizerMain.cs
+++ b/RandomizerMain.cs
@@ -510,16 +510,22 @@ namespace MessengerRando
         void LevelManager_EndLevelLoading(On.LevelManager.orig_EndLevelLoading orig, LevelManager self)
         {
             #if DEBUG
-            Console.WriteLine($"Finished loading into {Manager<LevelManager>.Instance.GetCurrentLevelEnum()}. " +
+            Console.WriteLine($"Finished loading into {self.GetCurrentLevelEnum()}. " +
                               $"player position: {Manager<PlayerManager>.Instance.Player.transform.position.x}, " +
-                              $"{Manager<PlayerManager>.Instance.Player.transform.position.y}");
+                              $"{Manager<PlayerManager>.Instance.Player.transform.position.y}, " +
+                              $"last level: {self.lastLevelLoaded}, " +
+                              $"scene: {self.CurrentSceneName}");
             #endif
             orig(self);
             // put the region we just loaded into in AP data storage for tracking
             if (ArchipelagoClient.Authenticated)
             {
-                ArchipelagoClient.Session.DataStorage[Scope.Slot, "CurrentRegion"] =
-                    self.GetCurrentLevelEnum().ToString();
+                if (self.lastLevelLoaded.Equals(ELevel.Level_13_TowerOfTimeHQ + "_Build"))
+                    ArchipelagoClient.Session.DataStorage[Scope.Slot, "CurrentRegion"] =
+                        ELevel.Level_13_TowerOfTimeHQ.ToString();
+                else
+                    ArchipelagoClient.Session.DataStorage[Scope.Slot, "CurrentRegion"] =
+                        self.GetCurrentLevelEnum().ToString();
             }
             if (Manager<LevelManager>.Instance.GetCurrentLevelEnum().Equals(ELevel.Level_11_B_MusicBox) &&
                 randoStateManager.SkipMusicBox && randoStateManager.IsSafeTeleportState())

--- a/RandomizerMain.cs
+++ b/RandomizerMain.cs
@@ -172,7 +172,6 @@ namespace MessengerRando
             On.InGameHud.OnGUI += InGameHud_OnGUI;
             On.SaveManager.DoActualSaving += SaveManager_DoActualSave;
             On.Quarble.OnPlayerDied += Quarble_OnPlayerDied;
-            On.LevelManager.OnLevelLoaded += LevelManager_onLevelLoaded;
             //temp add
             #if DEBUG
             On.MegaTimeShard.OnBreakDone += MegaTimeShard_OnBreakDone;
@@ -182,6 +181,7 @@ namespace MessengerRando
             On.MusicBox.SetNotesState += MusicBox_SetNotesState;
             On.PowerSeal.OnEnterRoom += PowerSeal_OnEnterRoom;
             On.LevelManager.LoadLevel += LevelManager_LoadLevel;
+            On.LevelManager.OnLevelLoaded += LevelManager_onLevelLoaded;
             #endif
             On.DialogSequence.GetDialogList += DialogSequence_GetDialogList;
             On.LevelManager.EndLevelLoading += LevelManager_EndLevelLoading;
@@ -504,13 +504,6 @@ namespace MessengerRando
         System.Collections.IEnumerator LevelManager_onLevelLoaded(On.LevelManager.orig_OnLevelLoaded orig,
             LevelManager self, Scene scene)
         {
-            // put the region we just loaded into in AP data storage for tracking
-            if (ArchipelagoClient.Authenticated)
-            {
-                ArchipelagoClient.Session.DataStorage[Scope.Slot, "CurrentRegion"] =
-                    self.GetCurrentLevelEnum().ToString();
-            }
-
             return orig(self, scene);
         }
 
@@ -522,6 +515,12 @@ namespace MessengerRando
                               $"{Manager<PlayerManager>.Instance.Player.transform.position.y}");
             #endif
             orig(self);
+            // put the region we just loaded into in AP data storage for tracking
+            if (ArchipelagoClient.Authenticated)
+            {
+                ArchipelagoClient.Session.DataStorage[Scope.Slot, "CurrentRegion"] =
+                    self.GetCurrentLevelEnum().ToString();
+            }
             if (Manager<LevelManager>.Instance.GetCurrentLevelEnum().Equals(ELevel.Level_11_B_MusicBox) &&
                 randoStateManager.SkipMusicBox && randoStateManager.IsSafeTeleportState())
             {

--- a/RandomizerMain.cs
+++ b/RandomizerMain.cs
@@ -558,7 +558,7 @@ namespace MessengerRando
             {
                 Console.WriteLine($"Note cutscene check! Handling note '{self.noteToAward}' | Linked item: '{randoStateManager.CurrentLocationToItemMapping[noteCheck]}'");
                 //bool shouldPlay = Manager<InventoryManager>.Instance.GetItemQuantity(randoStateManager.CurrentLocationToItemMapping[noteCheck].Item) <= 0 && !randoStateManager.IsNoteCutsceneTriggered(self.noteToAward);
-                bool shouldPlay = !randoStateManager.GetSeedForFileSlot(randoStateManager.CurrentFileSlot).CollectedItems.Contains(randoStateManager.CurrentLocationToItemMapping[noteCheck]) && !randoStateManager.IsNoteCutsceneTriggered(self.noteToAward);
+                bool shouldPlay = !randoStateManager.IsNoteCutsceneTriggered(self.noteToAward);
 
                 Console.WriteLine($"Should '{self.noteToAward}' cutscene play? '{shouldPlay}'");
                 
@@ -699,6 +699,11 @@ namespace MessengerRando
             if(randoStateManager.IsRandomizedFile && randoStateManager.IsLocationRandomized(EItems.NECROPHOBIC_WORKER, out necroLocation))
             {
                 //check to see if we already have the item at Necro check
+                if (ArchipelagoClient.HasConnected &&
+                    !ArchipelagoClient.ServerData.CheckedLocations.Contains(
+                        ItemsAndLocationsHandler.LocationsLookup[necroLocation]))
+                    self.necrophobicWorkerCutscene.Play();
+                
                 //if (Manager<InventoryManager>.Instance.GetItemQuantity(randoStateManager.CurrentLocationToItemMapping[new LocationRO(EItems.NECROPHOBIC_WORKER.ToString())].Item) <= 0 && !Manager<DemoManager>.Instance.demoMode)
                 if (!randoStateManager.GetSeedForFileSlot(randoStateManager.CurrentFileSlot).CollectedItems.Contains(randoStateManager.CurrentLocationToItemMapping[necroLocation]) && !Manager<DemoManager>.Instance.demoMode)
                 {

--- a/Utils/RandomizerStateManager.cs
+++ b/Utils/RandomizerStateManager.cs
@@ -11,6 +11,7 @@ namespace MessengerRando
     {
         public static RandomizerStateManager Instance { private set; get; }
         public Dictionary<LocationRO, RandoItemRO> CurrentLocationToItemMapping { set; get; }
+        public Dictionary<int, List<string>> DefeatedBosses { set; get; }
 
         public bool IsRandomizedFile { set; get; }
         public int CurrentFileSlot { set; get; }
@@ -96,6 +97,7 @@ namespace MessengerRando
             if (seeds.ContainsKey(fileSlot))
             {
                 seeds[fileSlot] = new SeedRO(fileSlot, SeedType.None, 0, null, null, null);
+                DefeatedBosses[fileSlot] = new List<string>();
             }
             Console.WriteLine("File slot reset complete.");
         }

--- a/Utils/RandomizerStateManager.cs
+++ b/Utils/RandomizerStateManager.cs
@@ -11,7 +11,7 @@ namespace MessengerRando
     {
         public static RandomizerStateManager Instance { private set; get; }
         public Dictionary<LocationRO, RandoItemRO> CurrentLocationToItemMapping { set; get; }
-        public Dictionary<int, List<string>> DefeatedBosses { set; get; }
+        public Dictionary<int, List<string>> DefeatedBosses;
 
         public bool IsRandomizedFile { set; get; }
         public int CurrentFileSlot { set; get; }
@@ -97,6 +97,7 @@ namespace MessengerRando
             if (seeds.ContainsKey(fileSlot))
             {
                 seeds[fileSlot] = new SeedRO(fileSlot, SeedType.None, 0, null, null, null);
+                if (DefeatedBosses == null) DefeatedBosses = new Dictionary<int, List<string>>();
                 DefeatedBosses[fileSlot] = new List<string>();
             }
             Console.WriteLine("File slot reset complete.");


### PR DESCRIPTION
Apparently rooms in different maps can share the same roomkeys. Since I do have successful on the fly teleport code, this would cause the player to get teleported to the boss room while on a completely different map and not even entering a boss room.